### PR TITLE
refactor: use styleMap instead of unsafeCSS

### DIFF
--- a/src/repositoryCard/language.ts
+++ b/src/repositoryCard/language.ts
@@ -1,5 +1,6 @@
-import { type TemplateResult, css, html, unsafeCSS } from "lit";
+import { type TemplateResult, css, html } from "lit";
 
+import { styleMap } from "lit/directives/style-map.js";
 import colorMap from "./languageColors.json" with { type: "json" };
 
 export const languageStyles = css`
@@ -15,10 +16,9 @@ export const languageStyles = css`
 const renderLanguageColor = function (language: string): TemplateResult {
   const colorCode =
     colorMap[language as keyof typeof colorMap]?.color ?? "#808080";
-  const color = unsafeCSS(colorCode);
 
   return html`
-    <span class="language-color" style="background-color: ${color};"></span>
+    <span class="language-color" style=${styleMap({ backgroundColor: colorCode })}></span>
   `;
 };
 


### PR DESCRIPTION
This pull request refactors the `renderLanguageColor` function in `src/repositoryCard/language.ts` to improve security and maintainability by replacing `unsafeCSS` with `styleMap`. Additionally, it removes an unused import.

### Code security and maintainability improvements:
* Removed the usage of `unsafeCSS` in the `renderLanguageColor` function and replaced it with `styleMap` to safely apply dynamic styles. (`src/repositoryCard/language.ts`, [src/repositoryCard/language.tsL18-R21](diffhunk://#diff-76d1f4ef2406bdd4aebbd52a8da811e0af9cbcb3c555c1742e99b5309a3ec61eL18-R21))

### Cleanup:
* Removed the unused `unsafeCSS` import from the `lit` library. (`src/repositoryCard/language.ts`, [src/repositoryCard/language.tsL1-R3](diffhunk://#diff-76d1f4ef2406bdd4aebbd52a8da811e0af9cbcb3c555c1742e99b5309a3ec61eL1-R3))