### PR TITLE
feat: add fallback renderer

### DIFF
--- a/src/repositoryCard/index.ts
+++ b/src/repositoryCard/index.ts
@@ -1,8 +1,6 @@
 import { Task } from "@lit/task";
 import { LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-
-import { errorElement } from "../errorElement.ts";
 import { type GitHubRepository, getRepository } from "../lib/ghApi.ts";
 import {
   renderSkeleton,
@@ -106,6 +104,23 @@ export class RepositoryCard extends LitElement {
     });
   }
 
+  renderFallback() {
+    const repoName = renderName(this.name);
+
+    return renderRoot({
+      url: `https://github.com/${this.name}`,
+      avatar: nothing,
+      repoName,
+      forkSource: nothing,
+      description: nothing,
+      language: nothing,
+      stars: nothing,
+      forks: nothing,
+      license: nothing,
+      topics: nothing,
+    });
+  }
+
   renderRepository(repo: GitHubRepository) {
     const avatar =
       !this.noAvatar && repo.owner.avatar_url
@@ -150,10 +165,10 @@ export class RepositoryCard extends LitElement {
   render() {
     return this._fetchTask.render({
       pending: () => this.renderSkeleton(),
-      error: () => errorElement,
+      error: () => this.renderFallback(),
       complete: (repo) => {
         if (repo === null) {
-          return errorElement;
+          return this.renderFallback();
         }
 
         return this.renderRepository(repo);


### PR DESCRIPTION
This pull request introduces a fallback rendering method to improve the user experience when repository data cannot be fetched. The changes ensure that a basic repository card is displayed instead of a generic error element in such cases.

### Enhancements to `RepositoryCard` rendering:

* **Added `renderFallback` method**: A new method `renderFallback` was introduced to render a simplified repository card with minimal information (e.g., repository name and URL) when data fetching fails. (`src/repositoryCard/index.ts`, [src/repositoryCard/index.tsR109-R125](diffhunk://#diff-abeb0f781560c8687f2feb0b41c0073683c451060b3a604151d9ed9a4c90e8caR109-R125))
* **Updated error handling in `render` method**: The `render` method now uses the `renderFallback` method instead of displaying a generic error element for both `pending` and `complete` error states. (`src/repositoryCard/index.ts`, [src/repositoryCard/index.tsL153-R173](diffhunk://#diff-abeb0f781560c8687f2feb0b41c0073683c451060b3a604151d9ed9a4c90e8caL153-R173))